### PR TITLE
Fix for possibly undefined this

### DIFF
--- a/nopromise.js
+++ b/nopromise.js
@@ -41,7 +41,7 @@ var globalQ,
 
 // Try to find the fastest asynchronous scheduler for this environment:
 // setImmediate -> native Promise scheduler -> setTimeout
-sysAsync = this.setImmediate; // nodejs, IE 10+
+sysAsync = typeof setImmediate !== "undefined" && setImmediate; // nodejs, IE 10+
 try {
     staticNativePromise = Promise.resolve();
     sysAsync = sysAsync || function(f) { staticNativePromise.then(f) }; // Firefox/Chrome

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,2 @@
+var g = Function("return this")();
+if (!g.Promise) g.Promise = require("./nopromise");


### PR DESCRIPTION
Continuing: https://github.com/avih/nopromise/pull/1

>Also, in your repo, is there any reason to call it "mpv-promise" other than to make it easier to search "mpv" in the npm database?
>Because it doesn't have anything mpv-specific, right? it basically only packages this repo as npm package...

Yeah, I can rename and publish as `nopromise` instead. I just didn't want to squat your "nopromise" package name on the npm.